### PR TITLE
Update PostCSS to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/joshacheson/hexo-renderer-postcss#readme",
   "dependencies": {
     "cssnano": "^1.1.0",
-    "postcss": "^4.1.10"
+    "postcss": "^5.0.12"
   }
 }


### PR DESCRIPTION
Some plugins, such as `postcss-svg`, require the latest version of PostCSS.